### PR TITLE
Remove verilog header files built from Chisel .prm file.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -47,20 +47,13 @@ ifneq ($(PATCHVERILOG),"")
 endif
 
 
-verilog_consts_vh := $(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).vh
-$(verilog_consts_vh): $(firrtl_prm)
-	echo "\`ifndef CONST_VH" > $@
-	echo "\`define CONST_VH" >> $@
-	sed -r 's/\(([A-Za-z0-9_]+),([A-Za-z0-9_]+)\)/`define \1 \2/' $< >> $@
-	echo "\`endif // CONST_VH" >> $@
-
 .PHONY: verilog
-verilog: $(verilog) $(verilog_consts_vh)
+verilog: $(verilog)
 
 # Build .mcs
 mcs := $(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).mcs
-$(mcs): $(verilog) $(verilog_consts_vh)
-	VSRC_TOP=$(verilog) VSRC_CONSTS=$(verilog_consts_vh) EXTRA_VSRCS="$(EXTRA_FPGA_VSRCS)" $(MAKE) -C $(FPGA_DIR) mcs
+$(mcs): $(verilog)
+	VSRC_TOP=$(verilog) EXTRA_VSRCS="$(EXTRA_FPGA_VSRCS)" $(MAKE) -C $(FPGA_DIR) mcs
 	cp $(FPGA_DIR)/obj/system.mcs $@
 
 .PHONY: mcs

--- a/common.mk
+++ b/common.mk
@@ -30,8 +30,7 @@ $(FIRRTL_JAR): $(shell find $(rocketchip_dir)/firrtl/src/main/scala -iname "*.sc
 
 # Build .fir
 firrtl := $(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).fir
-firrtl_prm := $(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).prm
-$(firrtl) $(firrtl_prm): $(shell find $(base_dir)/src/main/scala -name '*.scala') $(FIRRTL_JAR)
+$(firrtl): $(shell find $(base_dir)/src/main/scala -name '*.scala') $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
 	$(SBT) "run-main rocketchip.Generator $(BUILD_DIR) $(PROJECT) $(MODEL) $(CONFIG_PROJECT) $(CONFIG)"
 

--- a/fpga/e300artydevkit/Makefile
+++ b/fpga/e300artydevkit/Makefile
@@ -6,7 +6,7 @@ VIVADOFLAGS := \
 
 bit := obj/system.bit
 $(bit): script/impl.tcl  script/init.tcl
-	VSRC_TOP=$(VSRC_TOP) VSRC_CONSTS=$(VSRC_CONSTS) EXTRA_VSRCS="$(EXTRA_VSRCS)" $(VIVADO) $(VIVADOFLAGS) -source script/init.tcl -source script/impl.tcl
+	VSRC_TOP=$(VSRC_TOP) EXTRA_VSRCS="$(EXTRA_VSRCS)" $(VIVADO) $(VIVADOFLAGS) -source script/init.tcl -source script/impl.tcl
 
 .PHONY: bit
 bit: $(bit)

--- a/fpga/e300artydevkit/script/prologue.tcl
+++ b/fpga/e300artydevkit/script/prologue.tcl
@@ -50,15 +50,10 @@ if {[info exists ::env(EXTRA_VSRCS)]} {
 #}
 
 set vsrc_top $::env(VSRC_TOP)
-set vsrc_consts $::env(VSRC_CONSTS)
 
-set_property verilog_define [list \
-                                 "VSRC_CONSTS=${vsrc_consts}" \
-                                 "VSRC_TOP=${vsrc_top}" \
-                                ] $obj
+set_property verilog_define [list "VSRC_TOP=${vsrc_top}"] $obj
 
 add_files -norecurse -fileset $obj $vsrc_top
-add_files -norecurse -fileset $obj $vsrc_consts
 
 if {[get_filesets -quiet sim_1] eq ""} {
   create_fileset -simset sim_1

--- a/fpga/e300artydevkit/src/system.v
+++ b/fpga/e300artydevkit/src/system.v
@@ -1,8 +1,5 @@
 `timescale 1ns/1ps
 
-`define STRINGIFY(x) `"x`"
-`include `STRINGIFY(`VSRC_CONSTS)
-
 module system
 (
   input wire CLK100MHZ,

--- a/fpga/u500vc707devkit/Makefile
+++ b/fpga/u500vc707devkit/Makefile
@@ -6,7 +6,7 @@ VIVADOFLAGS := \
 
 bit := obj/system.bit
 $(bit): script/impl.tcl  script/init.tcl
-	VSRC_TOP=$(VSRC_TOP) VSRC_CONSTS=$(VSRC_CONSTS) EXTRA_VSRCS="$(EXTRA_VSRCS)" $(VIVADO) $(VIVADOFLAGS) -source script/init.tcl -source script/impl.tcl
+	VSRC_TOP=$(VSRC_TOP) EXTRA_VSRCS="$(EXTRA_VSRCS)" $(VIVADO) $(VIVADOFLAGS) -source script/init.tcl -source script/impl.tcl
 
 .PHONY: bit
 bit: $(bit)

--- a/fpga/u500vc707devkit/script/prologue.tcl
+++ b/fpga/u500vc707devkit/script/prologue.tcl
@@ -50,15 +50,10 @@ if {[info exists ::env(EXTRA_VSRCS)]} {
 #}
 
 set vsrc_top $::env(VSRC_TOP)
-set vsrc_consts $::env(VSRC_CONSTS)
 
-set_property verilog_define [list \
-                                 "VSRC_CONSTS=${vsrc_consts}" \
-                                 "VSRC_TOP=${vsrc_top}" \
-                                ] $obj
+set_property verilog_define [list "VSRC_TOP=${vsrc_top}"] $obj
 
 add_files -norecurse -fileset $obj $vsrc_top
-add_files -norecurse -fileset $obj $vsrc_consts
 
 if {[get_filesets -quiet sim_1] eq ""} {
   create_fileset -simset sim_1

--- a/fpga/u500vc707devkit/src/system.v
+++ b/fpga/u500vc707devkit/src/system.v
@@ -2,9 +2,6 @@
 `timescale 1ns/1ps
 `default_nettype none
 
-`define STRINGIFY(x) `"x`"
-`include `STRINGIFY(`VSRC_CONSTS)
-
 module system
 (
   //200Mhz differential sysclk


### PR DESCRIPTION
Will coincidentally fix #2.

The `.prm` file that rocket-chip's Generator outputs is now deprecated and emits an empty file, so now there's no point in creating the `.vh` file from it. The coincidentally caused an incompatibility with BSD-based systems like macOS, since we were using a GNU-only `sed` flag to generate the `.vh` file.

This PR removes the `.vh` file and all references to it from the FPGA scripts. As a sanity check, I've confirmed that the E300 Arty Dev Kit's MCS file still works on an actual Arty board. I haven't tested the U500 VC707 Dev Kit, but can if you'd like me to.