### PR TITLE
u500: disable PCIe

### DIFF
--- a/Makefile.u500vc707devkit
+++ b/Makefile.u500vc707devkit
@@ -1,6 +1,6 @@
 # See LICENSE for license details.
 base_dir := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-BUILD_DIR := $(base_dir)/builds/u500vc707devkit
+BUILD_DIR := $(base_dir)/builds/u500vc707devkit-nopcie
 FPGA_DIR := $(base_dir)/fpga-shells/xilinx
 MODEL := U500VC707DevKitFPGAChip
 PROJECT := sifive.freedom.unleashed.u500vc707devkit

--- a/src/main/scala/unleashed/u500vc707devkit/FPGAChip.scala
+++ b/src/main/scala/unleashed/u500vc707devkit/FPGAChip.scala
@@ -29,7 +29,6 @@ object PinGen {
 
 class U500VC707DevKitFPGAChip(implicit override val p: Parameters)
     extends VC707Shell
-    with HasPCIe
     with HasDDR3 {
 
   //-----------------------------------------------------------------------
@@ -48,7 +47,6 @@ class U500VC707DevKitFPGAChip(implicit override val p: Parameters)
     connectDebugJTAG(dut)
     connectSPI      (dut)
     connectUART     (dut)
-    connectPCIe     (dut)
     connectMIG      (dut)
 
     //---------------------------------------------------------------------

--- a/src/main/scala/unleashed/u500vc707devkit/System.scala
+++ b/src/main/scala/unleashed/u500vc707devkit/System.scala
@@ -28,8 +28,7 @@ class U500VC707DevKitSystem(implicit p: Parameters) extends RocketCoreplex
     with HasPeripheryUART
     with HasPeripherySPI
     with HasPeripheryGPIO
-    with HasMemoryXilinxVC707MIG
-    with HasSystemXilinxVC707PCIeX1 {
+    with HasMemoryXilinxVC707MIG {
   override lazy val module = new U500VC707DevKitSystemModule(this)
 }
 
@@ -40,8 +39,7 @@ class U500VC707DevKitSystemModule[+L <: U500VC707DevKitSystem](_outer: L)
     with HasPeripheryUARTModuleImp
     with HasPeripherySPIModuleImp
     with HasPeripheryGPIOModuleImp
-    with HasMemoryXilinxVC707MIGModuleImp
-    with HasSystemXilinxVC707PCIeX1ModuleImp {
+    with HasMemoryXilinxVC707MIGModuleImp {
   // Reset vector is set to the location of the mask rom
   val maskROMParams = p(PeripheryMaskROMKey)
   global_reset_vector := maskROMParams(0).address.U


### PR DESCRIPTION
This PR disables PCIe in the u500 design, allowing it to boot without the FMC daughter card.