### PR TITLE
Adding Future Avalanche Board design files

### DIFF
--- a/Makefile.u500polarfireavalanchekit
+++ b/Makefile.u500polarfireavalanchekit
@@ -6,7 +6,7 @@ MODEL := U500PolarFireAvalancheKitFPGAChip
 PROJECT :=  sifive.freedom.unleashed.u500polarfireavalanchekit
 CONFIG_PROJECT := sifive.freedom.unleashed.u500polarfireavalanchekit
 export CONFIG := U500PolarFireAvalancheKitConfig
-export BOARD := vc707
+export BOARD := polarfireavalancheboard
 export BOOTROM_DIR := $(base_dir)/bootrom/sdboot
 
 rocketchip_dir := $(base_dir)/rocket-chip

--- a/Makefile.u500polarfireavalanchekit
+++ b/Makefile.u500polarfireavalanchekit
@@ -1,0 +1,24 @@
+# See LICENSE for license details.
+base_dir := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+BUILD_DIR := $(base_dir)/builds/u500polarfireavalanchekit
+FPGA_DIR := $(base_dir)/fpga-shells/microsemi
+MODEL := U500PolarFireAvalancheKitFPGAChip
+PROJECT :=  sifive.freedom.unleashed.u500polarfireavalanchekit
+CONFIG_PROJECT := sifive.freedom.unleashed.u500polarfireavalanchekit
+export CONFIG := U500PolarFireAvalancheKitConfig
+export BOARD := vc707
+export BOOTROM_DIR := $(base_dir)/bootrom/sdboot
+
+rocketchip_dir := $(base_dir)/rocket-chip
+sifiveblocks_dir := $(base_dir)/sifive-blocks
+VSRCS := \
+	$(rocketchip_dir)/src/main/resources/vsrc/AsyncResetReg.v \
+	$(rocketchip_dir)/src/main/resources/vsrc/plusarg_reader.v \
+	$(sifiveblocks_dir)/vsrc/SRLatch.v \
+	$(FPGA_DIR)/common/vsrc/PowerOnResetFPGAOnly.v \
+	$(FPGA_DIR)/$(BOARD)/vsrc/sdio.v \
+	$(FPGA_DIR)/$(BOARD)/vsrc/vc707reset.v \
+	$(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).rom.v \
+	$(BUILD_DIR)/$(CONFIG_PROJECT).$(CONFIG).v
+
+include common.mk

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
@@ -33,8 +33,6 @@ class U500PolarFireAvalancheKitPeripherals extends Config((site, here, up) => {
     SPIParams(rAddress = BigInt(0x64001000L)))
   case PeripheryGPIOKey => List(
     GPIOParams(address = BigInt(0x64002000L), width = 4))
-  /*case PeripheryMaskROMKey => List(
-    MaskROMParams(address = 0x10000, name = "BootROM"))*/
 })
 
 // Freedom U500 PolarFire Avalanche Kit
@@ -42,11 +40,9 @@ class U500PolarFireAvalancheKitConfig extends Config(
   new WithNExtTopInterrupts(0)   ++
   new U500PolarFireAvalancheKitPeripherals ++
   new FreedomUPolarFireAvalancheKitConfig ().alter((site,here,up) => {
-  //  case ErrorParams => ErrorParams(Seq(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=128)
     case PeripheryBusKey => up(PeripheryBusKey, site).copy(frequency = 50000000) // 50 MHz hperiphery
     case MemoryMicrosemiDDR3Key => PolarFireEvalKitDDR3Params(address = Seq(AddressSet(0x80000000L,0x40000000L-1))) //1GB
     case DTSTimebase => BigInt(1000000)
-    //case ExtMem => up(ExtMem).map(_.copy(size = 0x40000000L))
     case JtagDTMKey => new JtagDTMConfig (
       idcodeVersion = 2,      // 1 was legacy (FE310-G000, Acai).
       idcodePartNum = 0x000,  // Decided to simplify.

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
@@ -2,7 +2,6 @@
 package sifive.freedom.unleashed.u500polarfireavalanchekit
 
 import freechips.rocketchip.config._
-//import freechips.rocketchip.coreplex._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.devices.tilelink._
@@ -14,8 +13,8 @@ import sifive.blocks.devices.gpio._
 import sifive.blocks.devices.spi._
 import sifive.blocks.devices.uart._
 
-import sifive.fpgashells.devices.microsemi.polarfireddr3.{MemoryMicrosemiDDR3Key, PolarFireEvalKitDDR3Params}
-import sifive.fpgashells.devices.microsemi.polarfireddr4.{MemoryMicrosemiDDR4Key, PolarFireEvalKitDDR4Params}
+import sifive.fpgashells.devices.microsemi.polarfireddr3.{MemoryMicrosemiAvalancheBoardDDR3Key, PolarFireAvalancheBoardDDR3Params}
+
 
 // Default FreedomU PolarFire Avalanche Kit Config
 class FreedomUPolarFireAvalancheKitConfig  extends Config(
@@ -41,7 +40,7 @@ class U500PolarFireAvalancheKitConfig extends Config(
   new U500PolarFireAvalancheKitPeripherals ++
   new FreedomUPolarFireAvalancheKitConfig ().alter((site,here,up) => {
     case PeripheryBusKey => up(PeripheryBusKey, site).copy(frequency = 50000000) // 50 MHz hperiphery
-    case MemoryMicrosemiDDR3Key => PolarFireEvalKitDDR3Params(address = Seq(AddressSet(0x80000000L,0x40000000L-1))) //1GB
+    case MemoryMicrosemiAvalancheBoardDDR3Key => PolarFireAvalancheBoardDDR3Params(address = Seq(AddressSet(0x80000000L,0x40000000L-1))) //1GB
     case DTSTimebase => BigInt(1000000)
     case JtagDTMKey => new JtagDTMConfig (
       idcodeVersion = 2,      // 1 was legacy (FE310-G000, Acai).

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/Config.scala
@@ -1,0 +1,56 @@
+// See LICENSE for license details.
+package sifive.freedom.unleashed.u500polarfireavalanchekit
+
+import freechips.rocketchip.config._
+//import freechips.rocketchip.coreplex._
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.devices.debug._
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.system._
+import freechips.rocketchip.tile._
+
+import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.spi._
+import sifive.blocks.devices.uart._
+
+import sifive.fpgashells.devices.microsemi.polarfireddr3.{MemoryMicrosemiDDR3Key, PolarFireEvalKitDDR3Params}
+import sifive.fpgashells.devices.microsemi.polarfireddr4.{MemoryMicrosemiDDR4Key, PolarFireEvalKitDDR4Params}
+
+// Default FreedomU PolarFire Avalanche Kit Config
+class FreedomUPolarFireAvalancheKitConfig  extends Config(
+  new WithJtagDTM            ++
+  new WithNMemoryChannels(1) ++
+  new WithNBigCores(1)       ++
+  new BaseConfig
+)
+
+// Freedom U500 PolarFire Eval Kit Peripherals
+class U500PolarFireAvalancheKitPeripherals extends Config((site, here, up) => {
+  case PeripheryUARTKey => List(
+    UARTParams(address = BigInt(0x64000000L)))
+  case PeripherySPIKey => List(
+    SPIParams(rAddress = BigInt(0x64001000L)))
+  case PeripheryGPIOKey => List(
+    GPIOParams(address = BigInt(0x64002000L), width = 4))
+  /*case PeripheryMaskROMKey => List(
+    MaskROMParams(address = 0x10000, name = "BootROM"))*/
+})
+
+// Freedom U500 PolarFire Avalanche Kit
+class U500PolarFireAvalancheKitConfig extends Config(
+  new WithNExtTopInterrupts(0)   ++
+  new U500PolarFireAvalancheKitPeripherals ++
+  new FreedomUPolarFireAvalancheKitConfig ().alter((site,here,up) => {
+  //  case ErrorParams => ErrorParams(Seq(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=128)
+    case PeripheryBusKey => up(PeripheryBusKey, site).copy(frequency = 50000000) // 50 MHz hperiphery
+    case MemoryMicrosemiDDR3Key => PolarFireEvalKitDDR3Params(address = Seq(AddressSet(0x80000000L,0x40000000L-1))) //1GB
+    case DTSTimebase => BigInt(1000000)
+    //case ExtMem => up(ExtMem).map(_.copy(size = 0x40000000L))
+    case JtagDTMKey => new JtagDTMConfig (
+      idcodeVersion = 2,      // 1 was legacy (FE310-G000, Acai).
+      idcodePartNum = 0x000,  // Decided to simplify.
+      idcodeManufId = 0x489,  // As Assigned by JEDEC to SiFive. Only used in wrappers / test harnesses.
+      debugIdleCycles = 5)    // Reasonable guess for synchronization
+  })
+)

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/FPGAChip.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/FPGAChip.scala
@@ -1,0 +1,73 @@
+// See LICENSE for license details.
+package sifive.freedom.unleashed.u500polarfireavalanchekit
+
+import Chisel._
+import chisel3.experimental.{withClockAndReset}
+
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+
+import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.pinctrl.{BasePin}
+
+import sifive.fpgashells.devices.microsemi.polarfireddr4._
+import sifive.fpgashells.shell.microsemi.polarfireavalanchekitshell._
+
+//-------------------------------------------------------------------------
+// PinGen
+//-------------------------------------------------------------------------
+
+object PinGen {
+  def apply(): BasePin = {
+    new BasePin()
+  }
+}
+
+//-------------------------------------------------------------------------
+// U500VC707DevKitFPGAChip
+//-------------------------------------------------------------------------
+
+
+class U500PolarFireAvalancheKitFPGAChip(implicit override val p: Parameters)
+    extends PolarFireAvalancheKitShell
+    //with HasPCIe
+    with HasDDR3 {
+
+  //-----------------------------------------------------------------------
+  // DUT
+  //-----------------------------------------------------------------------
+
+  // Connect the clock to the 50 Mhz output from the PLL
+//<CJ>  dut_clock := clk50
+  withClockAndReset(dut_clock, dut_reset) {
+    val dut = Module(LazyModule(new U500PolarFireAvalancheKitSystem).module)
+
+    //---------------------------------------------------------------------
+    // Connect peripherals
+    //---------------------------------------------------------------------
+
+    connectDebugJTAG(dut)
+    //connectSPI      (dut)
+    connectUART     (dut)
+    //connectPCIe     (dut)
+    connectMIG      (dut)
+
+    //---------------------------------------------------------------------
+    // GPIO
+    //---------------------------------------------------------------------
+
+    val gpioParams = p(PeripheryGPIOKey)
+    val gpio_pins = Wire(new GPIOPins(() => PinGen(), gpioParams(0)))
+
+    GPIOPinsFromPort(gpio_pins, dut.gpio(0))
+
+    gpio_pins.pins.foreach { _.i.ival := Bool(false) }
+    gpio_pins.pins.zipWithIndex.foreach {
+      case(pin, idx) => led(idx) := pin.o.oval
+    }
+
+    // tie to zero
+    for( idx <- 7 to 4 ) { led(idx) := false.B }
+  }
+
+}

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/FPGAChip.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/FPGAChip.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.diplomacy._
 import sifive.blocks.devices.gpio._
 import sifive.blocks.devices.pinctrl.{BasePin}
 
-import sifive.fpgashells.devices.microsemi.polarfireddr4._
+import sifive.fpgashells.devices.microsemi.polarfireddr3._
 import sifive.fpgashells.shell.microsemi.polarfireavalanchekitshell._
 
 //-------------------------------------------------------------------------
@@ -30,7 +30,6 @@ object PinGen {
 
 class U500PolarFireAvalancheKitFPGAChip(implicit override val p: Parameters)
     extends PolarFireAvalancheKitShell
-    //with HasPCIe
     with HasDDR3 {
 
   //-----------------------------------------------------------------------
@@ -38,7 +37,6 @@ class U500PolarFireAvalancheKitFPGAChip(implicit override val p: Parameters)
   //-----------------------------------------------------------------------
 
   // Connect the clock to the 50 Mhz output from the PLL
-//<CJ>  dut_clock := clk50
   withClockAndReset(dut_clock, dut_reset) {
     val dut = Module(LazyModule(new U500PolarFireAvalancheKitSystem).module)
 
@@ -47,9 +45,7 @@ class U500PolarFireAvalancheKitFPGAChip(implicit override val p: Parameters)
     //---------------------------------------------------------------------
 
     connectDebugJTAG(dut)
-    //connectSPI      (dut)
     connectUART     (dut)
-    //connectPCIe     (dut)
     connectMIG      (dut)
 
     //---------------------------------------------------------------------

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
@@ -25,7 +25,7 @@ class U500PolarFireAvalancheKitSystem(implicit p: Parameters) extends RocketSubs
     with HasPeripheryDebug
     with HasPeripheryUART
     with HasPeripheryGPIO
-    with HasMemoryPolarFireEvalKitDDR3{
+    with HasMemoryPolarFireAvalancheBoardDDR3{
   override lazy val module = new U500PolarFireAvalancheKitSystemModule(this)
 }
 
@@ -35,7 +35,7 @@ class U500PolarFireAvalancheKitSystemModule[+L <: U500PolarFireAvalancheKitSyste
     with HasPeripheryDebugModuleImp
     with HasPeripheryUARTModuleImp
     with HasPeripheryGPIOModuleImp
-    with HasMemoryPolarFireEvalKitDDR3ModuleImp
+    with HasMemoryPolarFireAvalancheBoardDDR3ModuleImp
     //with HasSystemPolarFireEvalKitPCIeX4ModuleImp
     {
   // Reset vector is set to the location of the mask rom

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
@@ -4,7 +4,6 @@ package sifive.freedom.unleashed.u500polarfireavalanchekit
 import Chisel._
 
 import freechips.rocketchip.config._
-//import freechips.rocketchip.coreplex._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.devices.tilelink._
@@ -12,12 +11,10 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.system._
 
 import sifive.blocks.devices.gpio._
-import sifive.blocks.devices.spi._
 import sifive.blocks.devices.uart._
 
 import sifive.fpgashells.devices.microsemi.polarfireddr3._
-import sifive.fpgashells.devices.microsemi.polarfireddr4._
-import sifive.fpgashells.devices.microsemi.polarfireevalkitpciex4._
+
 
 //-------------------------------------------------------------------------
 // U500PolarFireEvalKitSystem
@@ -25,27 +22,18 @@ import sifive.fpgashells.devices.microsemi.polarfireevalkitpciex4._
 
 //class U500PolarFireAvalancheKitSystem(implicit p: Parameters) extends RocketCoreplex
 class U500PolarFireAvalancheKitSystem(implicit p: Parameters) extends RocketSubsystem
-    //with HasPeripheryMaskROMSlave
     with HasPeripheryDebug
-    //with HasSystemErrorSlave
     with HasPeripheryUART
-    //with HasPeripherySPI
     with HasPeripheryGPIO
-//    with HasCoreJTAGDebug
-//    with HasMemoryPolarFireEvalKitDDR4
-    with HasMemoryPolarFireEvalKitDDR3
-    //with HasSystemPolarFireEvalKitPCIeX4
-    {
+    with HasMemoryPolarFireEvalKitDDR3{
   override lazy val module = new U500PolarFireAvalancheKitSystemModule(this)
 }
 
 class U500PolarFireAvalancheKitSystemModule[+L <: U500PolarFireAvalancheKitSystem](_outer: L)
   extends RocketSubsystemModuleImp(_outer)
-//  extends RocketCoreplexModule(_outer)
     with HasRTCModuleImp
     with HasPeripheryDebugModuleImp
     with HasPeripheryUARTModuleImp
-    //with HasPeripherySPIModuleImp
     with HasPeripheryGPIOModuleImp
     with HasMemoryPolarFireEvalKitDDR3ModuleImp
     //with HasSystemPolarFireEvalKitPCIeX4ModuleImp

--- a/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
+++ b/src/main/scala/unleashed/u500polarfireavalanchekit/System.scala
@@ -1,0 +1,57 @@
+// See LICENSE for license details.
+package sifive.freedom.unleashed.u500polarfireavalanchekit
+
+import Chisel._
+
+import freechips.rocketchip.config._
+//import freechips.rocketchip.coreplex._
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.devices.debug._
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.system._
+
+import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.spi._
+import sifive.blocks.devices.uart._
+
+import sifive.fpgashells.devices.microsemi.polarfireddr3._
+import sifive.fpgashells.devices.microsemi.polarfireddr4._
+import sifive.fpgashells.devices.microsemi.polarfireevalkitpciex4._
+
+//-------------------------------------------------------------------------
+// U500PolarFireEvalKitSystem
+//-------------------------------------------------------------------------
+
+//class U500PolarFireAvalancheKitSystem(implicit p: Parameters) extends RocketCoreplex
+class U500PolarFireAvalancheKitSystem(implicit p: Parameters) extends RocketSubsystem
+    //with HasPeripheryMaskROMSlave
+    with HasPeripheryDebug
+    //with HasSystemErrorSlave
+    with HasPeripheryUART
+    //with HasPeripherySPI
+    with HasPeripheryGPIO
+//    with HasCoreJTAGDebug
+//    with HasMemoryPolarFireEvalKitDDR4
+    with HasMemoryPolarFireEvalKitDDR3
+    //with HasSystemPolarFireEvalKitPCIeX4
+    {
+  override lazy val module = new U500PolarFireAvalancheKitSystemModule(this)
+}
+
+class U500PolarFireAvalancheKitSystemModule[+L <: U500PolarFireAvalancheKitSystem](_outer: L)
+  extends RocketSubsystemModuleImp(_outer)
+//  extends RocketCoreplexModule(_outer)
+    with HasRTCModuleImp
+    with HasPeripheryDebugModuleImp
+    with HasPeripheryUARTModuleImp
+    //with HasPeripherySPIModuleImp
+    with HasPeripheryGPIOModuleImp
+    with HasMemoryPolarFireEvalKitDDR3ModuleImp
+    //with HasSystemPolarFireEvalKitPCIeX4ModuleImp
+    {
+  // Reset vector is set to the location of the mask rom
+  //val maskROMParams = p(PeripheryMaskROMKey)
+//  global_reset_vector := maskROMParams(0).address.U
+  global_reset_vector := BigInt(0x80000000L).U
+}


### PR DESCRIPTION
Hi,

Opening pull request to add design files for the Future Avalanche Board.
This design contains an RV64IMAFDC rocket core with SiFive Blocks (UART and GPIO).
The GPIOs are connected to the 4 LEDs on the board and the UART is connected to the FTDI UART pins. 

There is also a script in the FPGA shell which I'll put a link to in a comment to follow that will build the complete libero project in Libero 12.  all the constraints are also included in the FPGA-Shell.  I will create a pull request for this in the next few minutes.

Let me know if you need me to do any updates to this work.

Thanks,
Ciaran 

