### PR TITLE
Reduce time to install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install required additional packages.
 ```
 sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev python wget
 
-sudo apt-get install default-jdk
+sudo apt-get install default-jre
 ```
 
 ### Install sbt, varilator and scala which are required for building from Chisel


### PR DESCRIPTION
It does not require to install entire jdk for building. It is purely for reduing the time of downloading packages for the build.