### PR TITLE
Changed the Configuration of the E300 Core

### DIFF
--- a/src/main/scala/everywhere/e300artydevkit/Config.scala
+++ b/src/main/scala/everywhere/e300artydevkit/Config.scala
@@ -21,6 +21,9 @@ class DefaultFreedomEConfig extends Config (
   new WithNBreakpoints(2)        ++
   new WithNExtTopInterrupts(0)   ++
   new WithJtagDTM                ++
+  new WithL1ICacheWays(2)        ++
+  new WithL1ICacheSets(128)      ++
+  new WithDefaultBtb             ++
   new TinyConfig
 )
 
@@ -61,5 +64,8 @@ class E300ArtyDevKitConfig extends Config(
       idcodePartNum = 0x000,
       idcodeManufId = 0x489,
       debugIdleCycles = 5)
+    case RocketTilesKey => up(RocketTilesKey, site) map { r =>
+      r.copy(icache = r.icache.map(_.copy(itimAddr = Some(0x8000000L))))
+    }
   })
 )


### PR DESCRIPTION
The configuration of the TinyCore which is used in the TinyConfig, does not match with the Configuration, that is described in the [FE310 Manual](https://sifive.cdn.prismic.io/sifive%2F59a1f74e-d918-41c5-b837-3fe01ba7eaa1_fe310-g002-manual-v19p05.pdf). The TinyCore has no branch target predictor and only a 4kb direct-mapped I-Cache.

This commit adds a btp and changes the I-Cache to a 16kb 2-way I-Cache